### PR TITLE
TOR-16 - Update to new API to Submit Songs

### DIFF
--- a/torjolan/Services/APIService.swift
+++ b/torjolan/Services/APIService.swift
@@ -21,6 +21,10 @@ struct StreamResponse: Codable, Equatable {
     let cover_url: String
 }
 
+struct StreamResponseList: Codable {
+    let tracks: [StreamResponse]
+}
+
 struct SearchResult: Codable {
     let id: String
     let artist: String
@@ -158,7 +162,7 @@ class APIService {
         return try JSONDecoder().decode(CreateStationResponse.self, from: data)
     }
     
-    func getStationStream(stationId: Int) async throws -> StreamResponse {
+    func getStationStream(stationId: Int) async throws -> StreamResponseList {
         guard let url = URL(string: "\(baseURL)/api/station/\(stationId)") else {
             throw APIError.invalidURL
         }
@@ -186,7 +190,7 @@ class APIService {
             throw APIError.invalidResponse
         }
         
-        return try JSONDecoder().decode(StreamResponse.self, from: data)
+        return try JSONDecoder().decode(StreamResponseList.self, from: data)
     }
     
     func thumbsUp(stationId: Int, songId: String) async throws -> Bool {

--- a/torjolan/Services/APIService.swift
+++ b/torjolan/Services/APIService.swift
@@ -192,6 +192,28 @@ class APIService {
         
         return try JSONDecoder().decode(StreamResponseList.self, from: data)
     }
+
+    func submitSong(stationId: Int, songId: String) async throws -> Bool {
+        guard let url = URL(string: "\(baseURL)/api/station/\(stationId)/\(songId)") else {
+            throw APIError.invalidURL
+        }
+        
+        var request = authorizedRequest(url)
+        request.httpMethod = "PUT"
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 401 {
+                throw APIError.unauthorized
+            }
+            throw APIError.invalidResponse
+        }
+        
+        let result = try JSONDecoder().decode(SuccessResponse.self, from: data)
+        return result.success
+    }
     
     func thumbsUp(stationId: Int, songId: String) async throws -> Bool {
         guard let url = URL(string: "\(baseURL)/api/station/\(stationId)/\(songId)/thumbs_up") else {

--- a/torjolan/Services/DownloadCacheManager.swift
+++ b/torjolan/Services/DownloadCacheManager.swift
@@ -32,11 +32,14 @@ public actor DownloadCacheManager {
     // MARK: Public interface
     @discardableResult
     public func queue(songId: String, url: URL) async -> StreamLoader {
+        os_log("Queue: %@", log: self.appLog, type: .info, songId)
         let dest = destinationURL(for: songId, remoteURL: url)
         touchFileAccessDate(dest)
 
         if !(isFileComplete(dest) ?? false) &&
-            !pending.contains(where: { $0.songId == songId }) {
+             !pending.contains(where: { $0.songId == songId }) &&
+             !active.contains(where: { $0.songId == songId }) {
+            os_log("Song: %@ is being added to queue which has %d songs in it", log: self.appLog, type: .debug, songId, self.pending.count)
 
             // do a HEAD on the request, we need some metadata
             let meta0  = FileMeta(remoteURL: url)
@@ -49,12 +52,22 @@ public actor DownloadCacheManager {
 
             return streamLoader
         } else if let index = pending.firstIndex(where: { $0.songId == songId }) {
+            os_log("Song: %@ is in pending list already", log: self.appLog, type: .debug, songId)
             // This item is in our pending queue,
             // return a handle to the StreamLoader
             //
             // !mwd - In the future, we should move this to the front of the queue
             return pending[index].streamLoader
+        } else if let index = active.firstIndex(where: { $0.songId == songId }) {
+            os_log("Song: %@ is in active list already", log: self.appLog, type: .debug, songId)
+            // This item is in our active download queue,
+            // return a handle to the StreamLoader
+            //
+            // !mwd - In the future, we should move this to the front of the queue
+            return active[index].streamLoader
         } else {
+            os_log("Song: %@ is cached!", log: self.appLog, type: .debug, songId)
+
             var meta  = (try? readMeta(for: dest)) ?? FileMeta(remoteURL: url)
             let fileSize = localFileSize(dest)
             if meta.contentLength == nil {
@@ -110,21 +123,24 @@ public actor DownloadCacheManager {
     private let sizeLimit: UInt64
     private let cacheDir: URL
     private let session: URLSession
-    private var activeCount = 0
     private var pending: [DownloadRequest] = []
+    private var active: [DownloadRequest] = []
     private let appLog = OSLog(subsystem: "net.line72.torjolan", category: "DownloadCacheManager")
 
     // MARK: - Queue processing
     private func scheduleWorkIfNeeded() {
-        guard activeCount < maxConcurrent, !pending.isEmpty else { return }
+        guard self.active.count < maxConcurrent, !pending.isEmpty else { return }
         let next = pending.removeFirst()
-        activeCount += 1
+        self.active.append(next)
+
         Task.detached { [weak self] in
             await self?.download(request: next)
         }
     }
 
     private func download(request: DownloadRequest) async {
+        os_log("Start Download: %@", log: self.appLog, type: .info, request.songId)
+                 
         var fileHandle: FileHandle? = nil
         defer {
             try? fileHandle?.close()
@@ -221,12 +237,15 @@ public actor DownloadCacheManager {
             print("❌ ====================================")
         }
 
-        finishDownload()
+        finishDownload(request: request)
         await pruneIfNeeded(force: false)
     }
 
-    private func finishDownload() {
-        activeCount -= 1
+    private func finishDownload(request: DownloadRequest) {
+        os_log("Finished downloading song: %@", log: self.appLog, type: .debug, request.songId)
+        if let index = self.active.firstIndex(where: { $0.songId == request.songId }) {
+            self.active.remove(at: index)
+        }
         scheduleWorkIfNeeded()
     }
 

--- a/torjolan/Views/PlayerView.swift
+++ b/torjolan/Views/PlayerView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import AVFoundation
 import MediaPlayer
 import Combine
+import os.log
 
 class AudioPlayer: NSObject, ObservableObject {
     static let shared = AudioPlayer()
@@ -11,6 +12,12 @@ class AudioPlayer: NSObject, ObservableObject {
     private var playerItemStatusObserver: AnyCancellable?
     private var playerItemDidPlayToEndObserver: AnyCancellable?
 
+    private var submitted = false
+    private var nextUpSong: Song?
+    private var nextUpStreamLoader: StreamLoader?
+
+    private let appLog = OSLog(subsystem: "net.line72.torjolan", category: "PlayerView")
+    
     @Published var isPlaying = false
     @Published var currentTime: TimeInterval = 0
     @Published var currentSong: Song?
@@ -67,6 +74,23 @@ class AudioPlayer: NSObject, ObservableObject {
             guard let self = self else { return }
             self.currentTime = time.seconds
 
+            if ((self.currentTime as Double) / (self.duration as Double) >= 0.85) {
+                // We have reach 85%. Time to submit this as played and retrieve
+                // the next songs
+                if (!self.submitted) {
+                    // We can't run an async task in this callback,
+                    //  therefore we are going to spin up a new
+                    //  thread. However, submitAndGetNextSong must be
+                    //  run on the main thread, which is why we tell
+                    //  this to run on @MainActor
+                    Task { @MainActor in
+                        do {
+                            await self.submitAndGetNextSong(song: self.currentSong)
+                        }
+                    }
+                }
+            }
+            
             // Update lock screen progress
             if var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo {
                 nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = self.currentTime
@@ -148,6 +172,25 @@ class AudioPlayer: NSObject, ObservableObject {
         }
     }
 
+    /**
+     * If we have a nextSong in the queue, play it, otherwise
+     *  fetch from the server
+     */
+    private func playNextSong() async {
+        if let song = self.nextUpSong, let loader = self.nextUpStreamLoader {
+            os_log("playNextSong: Playing queued NextUp", log: self.appLog, type: .debug)
+            // we have items in the queue, play it
+            await MainActor.run {
+                self.nextUpSong = nil
+                self.nextUpStreamLoader = nil
+                
+                play(streamLoader: loader, song: song)
+            }
+        } else {
+            await fetchAndPlayNextSong()
+        }
+    }
+    
     private func fetchAndPlayNextSong() async {
         guard let station = currentStation else { return }
 
@@ -185,11 +228,72 @@ class AudioPlayer: NSObject, ObservableObject {
         }
     }
 
+    private func submitAndGetNextSong(song: Song?) async {
+        os_log("submitAndGetNextSong", log: self.appLog, type: .debug)
+        
+        guard song != nil else { return }
+        guard !self.submitted else { return }
+        guard let station = currentStation else { return }
+
+        self.submitted = true
+        
+        do {
+            // If this was thumbed up, it has already been
+            //  submitted
+            if (!self.isThumbedUp) {
+                os_log("Calling APIServer.submitSong", log: self.appLog, type: .debug)
+                // Submit this as played
+                let _ = try await APIService.shared.submitSong(stationId: station.id,
+                                                               songId: song?.id ?? "")
+            } else {
+                os_log("Song was thumbed up, skipping submit", log: self.appLog, type: .debug)
+            }
+
+            // Get the next Songs
+            let streamResponseList = try await APIService.shared.getStationStream(stationId: station.id)
+
+            do {
+                // Queue up and start playing the first song in the response
+                let firstStream = streamResponseList.tracks[0]
+                let song = Song(from: firstStream)
+                let streamLoader = await DownloadCacheManager.shared.queue(
+                    songId: song.id,
+                    url: URL(string: firstStream.url)!
+                )
+
+                os_log("Got our next song: %@", log: self.appLog, type: .debug, song.id)
+                
+                self.nextUpSong = song
+                self.nextUpStreamLoader = streamLoader
+
+                // Put the remaining songs in the download queue
+                //
+                // !mwd - This would be better if it was a priority
+                // queue. We have a good chance of backing up our
+                // queue with songs we won't play
+                for stream in streamResponseList.tracks.dropFirst() {
+                    let song2 = Song(from: stream)
+                    let _ = await DownloadCacheManager.shared.queue(
+                      songId: song2.id,
+                      url: URL(string: stream.url)!
+                    )
+                }
+            }
+        } catch {
+            print("Failed to fetch next song: \(error)")
+        }
+    }
+    
     func play(streamLoader: StreamLoader, song: Song) {
         print("Attempting to play URL: \(song.id)")
 
         stop()
 
+        // clear out any next song stuff
+        self.submitted = false
+        self.nextUpSong = nil
+        self.nextUpStreamLoader = nil
+        
         // Retain the stream loader strongly so it isn't deallocated
         currentStreamLoader = streamLoader
 
@@ -218,7 +322,7 @@ class AudioPlayer: NSObject, ObservableObject {
                 case .failed:
                     self?.logDetailedPlayerError(playerItem: playerItem, song: song)
                     Task {
-                        await self?.fetchAndPlayNextSong()
+                        await self?.playNextSong()
                     }
                 default:
                     print("Status changed to unknown \(status)")
@@ -232,7 +336,7 @@ class AudioPlayer: NSObject, ObservableObject {
             .sink { [weak self] _ in
                 print("✓ Media playback ended")
                 Task {
-                    await self?.fetchAndPlayNextSong()
+                    await self?.playNextSong()
                 }
             }
 

--- a/torjolan/Views/PlayerView.swift
+++ b/torjolan/Views/PlayerView.swift
@@ -152,17 +152,32 @@ class AudioPlayer: NSObject, ObservableObject {
         guard let station = currentStation else { return }
 
         do {
-            let streamResponse = try await APIService.shared.getStationStream(stationId: station.id)
-            let song = Song(from: streamResponse)
+            let streamResponseList = try await APIService.shared.getStationStream(stationId: station.id)
 
             do {
+                // Queue up and start playing the first song in the response
+                let firstStream = streamResponseList.tracks[0]
+                let song = Song(from: firstStream)
                 let streamLoader = await DownloadCacheManager.shared.queue(
                     songId: song.id,
-                    url: URL(string: streamResponse.url)!
+                    url: URL(string: firstStream.url)!
                 )
 
                 await MainActor.run {
                     play(streamLoader: streamLoader, song: song)
+                }
+
+                // Put the remaining songs in the download queue
+                //
+                // !mwd - This would be better if it was a priority
+                // queue. We have a good chance of backing up our
+                // queue with songs we won't play
+                for stream in streamResponseList.tracks.dropFirst() {
+                    let song2 = Song(from: stream)
+                    let _ = await DownloadCacheManager.shared.queue(
+                      songId: song2.id,
+                      url: URL(string: stream.url)!
+                    )
                 }
             }
         } catch {
@@ -418,8 +433,8 @@ struct PlayerView: View {
                             .bold()
                             .lineLimit(1)
                             .truncationMode(.tail)
-                            .frame(maxWidth: .infinity, alignment: .center)
-
+                            .frame(maxWidth: .infinity, alignment: .center
+)
                         Text(audioPlayer.currentSong?.artist ?? " ")  // Use space to maintain height
                             .font(.title3)
                             .foregroundColor(.secondary)


### PR DESCRIPTION
Resolves #16

- **Updated to the new API that returns multiple tracks. Put them all in the queue to be downloaded ahead of time. Fixed up returning cached items**
- **When we cross 85% played, submit the song as played and start queing up next songs**
