### PR TITLE
Make the download pending queue a priority queue

### DIFF
--- a/torjolan/Extensions/URL+QueryParams.swift
+++ b/torjolan/Extensions/URL+QueryParams.swift
@@ -1,0 +1,18 @@
+//
+//  URL+QueryParams.swift
+//
+import Foundation
+
+extension URL {
+    func addQueryParams(_ params: [String: String]) -> URL {
+        var c = URLComponents(url: self, resolvingAgainstBaseURL: false)
+        var items = c?.queryItems ?? []
+        params.forEach { name, value in
+            items.removeAll { $0.name == name }
+            items.append(.init(name: name, value: value))
+        }
+        c?.queryItems = items
+        return c?.url ?? self
+    }
+}
+// Usage: url.addQueryParams(["format": "mp3", "quality": "high"])

--- a/torjolan/Services/DownloadCacheManager.swift
+++ b/torjolan/Services/DownloadCacheManager.swift
@@ -178,7 +178,7 @@ public actor DownloadCacheManager {
     }
 
     private func download(request: DownloadRequest) async {
-        os_log("Start Download: %@", log: self.appLog, type: .info, request.songId)
+        os_log("Start Download: %@ | tasks: %d | active: %d | pending: %d", log: self.appLog, type: .info, request.songId, self.activeTasks.count, self.active.count, self.pending.count)
                  
         var fileHandle: FileHandle? = nil
         defer {
@@ -198,7 +198,7 @@ public actor DownloadCacheManager {
 
         let currentSize = localFileSize(dest)
         if let expected = meta.contentLength, currentSize == expected, meta.complete {
-            os_log("✓ Cached %@", request.songId); return
+            os_log("✓ Cached %@", log: self.appLog, type: .debug, request.songId); return
         }
 
         // !mwd - In the future, it would be cool to resume
@@ -391,10 +391,12 @@ public actor DownloadCacheManager {
     // MARK: Eviction
     private func pruneIfNeeded(force: Bool) async {
         let (total, files) = folderSizeAndFiles()
+        os_log("Pruning cache %d, total=%d of %d, files=%d", log: self.appLog, type: .debug, force, total, sizeLimit, files.count)
         guard force || total > sizeLimit else { return }
 
         var bytesToFree = total > sizeLimit ? total - sizeLimit : 0
         for stat in files where bytesToFree > 0 {
+            os_log("Deleting %@ from cache", log: self.appLog, type: .debug, stat.url.absoluteString)
             try? FileManager.default.removeItem(at: stat.url)
             try? FileManager.default.removeItem(at: metaURL(for: stat.url))
             bytesToFree = bytesToFree > stat.size ? bytesToFree - stat.size : 0

--- a/torjolan/Services/DownloadCacheManager.swift
+++ b/torjolan/Services/DownloadCacheManager.swift
@@ -30,6 +30,12 @@ public actor DownloadCacheManager {
     }
 
     // MARK: Public interface
+    public func cancel(songId: String) {
+        os_log("Cancel: %@", log: self.appLog, type: .info, songId)
+        self.activeTasks[songId]?.cancel()
+        self.activeTasks.removeValue(forKey: songId)
+    }
+    
     @discardableResult
     public func queue(songId: String, url: URL) async -> StreamLoader {
         os_log("Queue: %@", log: self.appLog, type: .info, songId)
@@ -38,7 +44,7 @@ public actor DownloadCacheManager {
 
     @discardableResult
     public func queueFirst(songId: String, url: URL) async -> StreamLoader {
-        os_log("QueueFirst: %@", log:self.appLog, type: .info, songId)
+        os_log("QueueFirst: %@", log: self.appLog, type: .info, songId)
         return await addToQueue(insertAtHead: true, songId: songId, url: url)
     }
 
@@ -63,11 +69,14 @@ public actor DownloadCacheManager {
             let streamLoader = StreamLoader(contentType: meta.contentType ?? "audio/mpeg", contentSize: Int64(meta.contentLength ?? 0))
             if (insertAtHead) {
                 pending.insert(DownloadRequest(songId: songId, remote: url, streamLoader: streamLoader), at: 0)
+                // force this download to start. We may go over our
+                // max concurrent downloads, but that is ok
+                scheduleWorkIfNeeded(force: true)
             } else {
                 pending.append(DownloadRequest(songId: songId, remote: url, streamLoader: streamLoader))
+                scheduleWorkIfNeeded()
             }
             
-            scheduleWorkIfNeeded()
 
             return streamLoader
         } else if let index = pending.firstIndex(where: { $0.songId == songId }) {
@@ -149,17 +158,23 @@ public actor DownloadCacheManager {
     private let session: URLSession
     private var pending: [DownloadRequest] = []
     private var active: [DownloadRequest] = []
+    private var activeTasks: [String: Task<()?, Never>] = [:] // songId -> Task
     private let appLog = OSLog(subsystem: "net.line72.torjolan", category: "DownloadCacheManager")
 
     // MARK: - Queue processing
-    private func scheduleWorkIfNeeded() {
-        guard self.active.count < maxConcurrent, !pending.isEmpty else { return }
+    private func scheduleWorkIfNeeded(force: Bool = false) {
+        // Only pass if force is true OR the active is less than our
+        // max concurrent and we have pending items
+        guard force || self.active.count < maxConcurrent, force || !pending.isEmpty else { return }
+
         let next = pending.removeFirst()
         self.active.append(next)
 
-        Task.detached { [weak self] in
+        let downloadTask = Task.detached { [weak self] in
             await self?.download(request: next)
         }
+
+        self.activeTasks[next.songId] = downloadTask
     }
 
     private func download(request: DownloadRequest) async {
@@ -241,6 +256,10 @@ public actor DownloadCacheManager {
 
         } catch {
             os_log("❌ Download failed %@: %@", log: self.appLog, type: .error, request.songId, error.localizedDescription)
+
+            // signal end of stream
+            request.streamLoader.signalEndOfStream()
+            
             print("❌ ========== DOWNLOAD FAILED ==========")
             print("❌ Song ID: \(request.songId)")
             print("❌ Remote URL: \(request.remote)")
@@ -270,6 +289,9 @@ public actor DownloadCacheManager {
         if let index = self.active.firstIndex(where: { $0.songId == request.songId }) {
             self.active.remove(at: index)
         }
+        // also remove the task
+        self.activeTasks.removeValue(forKey: request.songId)
+        
         scheduleWorkIfNeeded()
     }
 

--- a/torjolan/Services/DownloadCacheManager.swift
+++ b/torjolan/Services/DownloadCacheManager.swift
@@ -30,26 +30,26 @@ public actor DownloadCacheManager {
     }
 
     // MARK: Public interface
-    public func cancel(songId: String) {
+    func cancel(songId: String) {
         os_log("Cancel: %@", log: self.appLog, type: .info, songId)
         self.activeTasks[songId]?.cancel()
         self.activeTasks.removeValue(forKey: songId)
     }
     
     @discardableResult
-    public func queue(songId: String, url: URL) async -> StreamLoader {
-        os_log("Queue: %@", log: self.appLog, type: .info, songId)
-        return await addToQueue(insertAtHead: false, songId: songId, url: url)
+    func queue(song: Song, url: URL) async -> StreamLoader {
+        os_log("Queue: %@: %@ - %@", log: self.appLog, type: .info, song.id, song.artist, song.title)
+        return await addToQueue(insertAtHead: false, songId: song.id, url: url)
     }
 
     @discardableResult
-    public func queueFirst(songId: String, url: URL) async -> StreamLoader {
-        os_log("QueueFirst: %@", log: self.appLog, type: .info, songId)
-        return await addToQueue(insertAtHead: true, songId: songId, url: url)
+    func queueFirst(song: Song, url: URL) async -> StreamLoader {
+        os_log("QueueFirst: %@: %@ - %@", log: self.appLog, type: .info, song.id, song.artist, song.title)
+        return await addToQueue(insertAtHead: true, songId: song.id, url: url)
     }
 
     @discardableResult
-    public func addToQueue(insertAtHead: Bool, songId: String, url: URL) async -> StreamLoader {
+    func addToQueue(insertAtHead: Bool, songId: String, url: URL) async -> StreamLoader {
         os_log("addToQueue at head? %d: %@", log: self.appLog, type: .info, insertAtHead, songId)
         os_log("Active Downloads: %d", log: self.appLog, type: .info, active.count)
         os_log("Pending Downloads: %d", log: self.appLog, type: .info, pending.count)
@@ -74,7 +74,7 @@ public actor DownloadCacheManager {
             let meta = await metaWithHeadInfo(meta0)
             try? writeMeta(meta, for: dest)
 
-            let streamLoader = StreamLoader(contentType: meta.contentType ?? "audio/mpeg", contentSize: Int64(meta.contentLength ?? 0))
+            let streamLoader = StreamLoader(songId: songId, contentType: meta.contentType ?? "audio/mpeg", contentSize: Int64(meta.contentLength ?? 0))
             if (insertAtHead) {
                 pending.insert(DownloadRequest(songId: songId, remote: downloadUrl, streamLoader: streamLoader), at: 0)
                 // force this download to start. We may go over our
@@ -118,8 +118,9 @@ public actor DownloadCacheManager {
             }
 
             let streamLoader = StreamLoader(
-                contentType: meta.contentType ?? "audio/mpeg",
-                contentSize: Int64(meta.contentLength ?? fileSize)
+              songId: songId,
+              contentType: meta.contentType ?? "audio/mpeg",
+              contentSize: Int64(meta.contentLength ?? fileSize)
             )
 
             // Read the cached file and feed it to the StreamLoader in chunks
@@ -149,13 +150,13 @@ public actor DownloadCacheManager {
         }
     }
 
-    public func remove(songId: String) {
+    func remove(songId: String) {
         let url = destinationURL(for: songId, remoteURL: nil)
         try? FileManager.default.removeItem(at: url)
         try? FileManager.default.removeItem(at: metaURL(for: url))
     }
 
-    public func cleanup() async {
+    func cleanup() async {
         await pruneIfNeeded(force: true)
     }
 

--- a/torjolan/Services/DownloadCacheManager.swift
+++ b/torjolan/Services/DownloadCacheManager.swift
@@ -33,6 +33,20 @@ public actor DownloadCacheManager {
     @discardableResult
     public func queue(songId: String, url: URL) async -> StreamLoader {
         os_log("Queue: %@", log: self.appLog, type: .info, songId)
+        return await addToQueue(insertAtHead: false, songId: songId, url: url)
+    }
+
+    @discardableResult
+    public func queueFirst(songId: String, url: URL) async -> StreamLoader {
+        os_log("QueueFirst: %@", log:self.appLog, type: .info, songId)
+        return await addToQueue(insertAtHead: true, songId: songId, url: url)
+    }
+
+    @discardableResult
+    public func addToQueue(insertAtHead: Bool, songId: String, url: URL) async -> StreamLoader {
+        os_log("addToQueue at head? %d: %@", log: self.appLog, type: .info, insertAtHead, songId)
+        os_log("Active Downloads: %d", log: self.appLog, type: .info, active.count)
+        os_log("Pending Downloads: %d", log: self.appLog, type: .info, pending.count)
         let dest = destinationURL(for: songId, remoteURL: url)
         touchFileAccessDate(dest)
 
@@ -47,7 +61,12 @@ public actor DownloadCacheManager {
             try? writeMeta(meta, for: dest)
 
             let streamLoader = StreamLoader(contentType: meta.contentType ?? "audio/mpeg", contentSize: Int64(meta.contentLength ?? 0))
-            pending.append(DownloadRequest(songId: songId, remote: url, streamLoader: streamLoader))
+            if (insertAtHead) {
+                pending.insert(DownloadRequest(songId: songId, remote: url, streamLoader: streamLoader), at: 0)
+            } else {
+                pending.append(DownloadRequest(songId: songId, remote: url, streamLoader: streamLoader))
+            }
+            
             scheduleWorkIfNeeded()
 
             return streamLoader
@@ -56,14 +75,19 @@ public actor DownloadCacheManager {
             // This item is in our pending queue,
             // return a handle to the StreamLoader
             //
-            // !mwd - In the future, we should move this to the front of the queue
-            return pending[index].streamLoader
+            if (insertAtHead) {
+                // Move this to the top of the pending queue
+                let item = pending.remove(at: index);
+                pending.insert(item, at: 0)
+                return item.streamLoader
+            } else {
+                return pending[index].streamLoader
+            }
         } else if let index = active.firstIndex(where: { $0.songId == songId }) {
             os_log("Song: %@ is in active list already", log: self.appLog, type: .debug, songId)
             // This item is in our active download queue,
             // return a handle to the StreamLoader
             //
-            // !mwd - In the future, we should move this to the front of the queue
             return active[index].streamLoader
         } else {
             os_log("Song: %@ is cached!", log: self.appLog, type: .debug, songId)

--- a/torjolan/Services/DownloadCacheManager.swift
+++ b/torjolan/Services/DownloadCacheManager.swift
@@ -53,7 +53,15 @@ public actor DownloadCacheManager {
         os_log("addToQueue at head? %d: %@", log: self.appLog, type: .info, insertAtHead, songId)
         os_log("Active Downloads: %d", log: self.appLog, type: .info, active.count)
         os_log("Pending Downloads: %d", log: self.appLog, type: .info, pending.count)
-        let dest = destinationURL(for: songId, remoteURL: url)
+
+        // if transcode is enabled, convert to mp3
+        var downloadUrl = url
+        if (self.transcode) {
+            downloadUrl = url.addQueryParams(["format": "mp3"])
+        }
+        os_log("url=%@", log: self.appLog, type: .debug, downloadUrl.absoluteString)
+        
+        let dest = destinationURL(for: songId, remoteURL: downloadUrl)
         touchFileAccessDate(dest)
 
         if !(isFileComplete(dest) ?? false) &&
@@ -62,18 +70,18 @@ public actor DownloadCacheManager {
             os_log("Song: %@ is being added to queue which has %d songs in it", log: self.appLog, type: .debug, songId, self.pending.count)
 
             // do a HEAD on the request, we need some metadata
-            let meta0  = FileMeta(remoteURL: url)
+            let meta0  = FileMeta(remoteURL: downloadUrl)
             let meta = await metaWithHeadInfo(meta0)
             try? writeMeta(meta, for: dest)
 
             let streamLoader = StreamLoader(contentType: meta.contentType ?? "audio/mpeg", contentSize: Int64(meta.contentLength ?? 0))
             if (insertAtHead) {
-                pending.insert(DownloadRequest(songId: songId, remote: url, streamLoader: streamLoader), at: 0)
+                pending.insert(DownloadRequest(songId: songId, remote: downloadUrl, streamLoader: streamLoader), at: 0)
                 // force this download to start. We may go over our
                 // max concurrent downloads, but that is ok
                 scheduleWorkIfNeeded(force: true)
             } else {
-                pending.append(DownloadRequest(songId: songId, remote: url, streamLoader: streamLoader))
+                pending.append(DownloadRequest(songId: songId, remote: downloadUrl, streamLoader: streamLoader))
                 scheduleWorkIfNeeded()
             }
             
@@ -101,7 +109,7 @@ public actor DownloadCacheManager {
         } else {
             os_log("Song: %@ is cached!", log: self.appLog, type: .debug, songId)
 
-            var meta  = (try? readMeta(for: dest)) ?? FileMeta(remoteURL: url)
+            var meta  = (try? readMeta(for: dest)) ?? FileMeta(remoteURL: downloadUrl)
             let fileSize = localFileSize(dest)
             if meta.contentLength == nil {
                 // Backfill content length from local file size for accurate metadata
@@ -152,6 +160,7 @@ public actor DownloadCacheManager {
     }
 
     // MARK: - Internal storage
+    private let transcode: Bool = false
     private let maxConcurrent: Int
     private let sizeLimit: UInt64
     private let cacheDir: URL

--- a/torjolan/Services/DownloadCacheManager.swift
+++ b/torjolan/Services/DownloadCacheManager.swift
@@ -255,29 +255,34 @@ public actor DownloadCacheManager {
             touchFileAccessDate(dest)
 
         } catch {
-            os_log("❌ Download failed %@: %@", log: self.appLog, type: .error, request.songId, error.localizedDescription)
-
             // signal end of stream
             request.streamLoader.signalEndOfStream()
-            
-            print("❌ ========== DOWNLOAD FAILED ==========")
-            print("❌ Song ID: \(request.songId)")
-            print("❌ Remote URL: \(request.remote)")
-            print("❌ Error: \(error)")
-            print("❌ Error Type: \(type(of: error))")
-            
-            if let nsError = error as NSError? {
-                print("❌ NSError Domain: \(nsError.domain)")
-                print("❌ NSError Code: \(nsError.code)")
-                print("❌ NSError UserInfo: \(nsError.userInfo)")
+
+            if error is CancellationError {
+                os_log("Download %@ has been cancelled", log: self.appLog, type: .info, request.songId)
+            } else {
+                os_log("❌ Download failed %@: %@", log: self.appLog, type: .error, request.songId, error.localizedDescription)
+
+                os_log("❌ ========== DOWNLOAD FAILED ==========", log: self.appLog, type: .debug)
+                os_log("❌ Song ID: %@", log: self.appLog, type: .debug, request.songId)
+                os_log("❌ Remote URL: %@", log: self.appLog, type: .debug, request.remote as CVarArg)
+                os_log("❌ Error: %@", log: self.appLog, type: .debug, String(describing: error))
+                os_log("❌ Error Type: %@", log: self.appLog, type: .debug, String(reflecting: type(of: error)))
+                
+                if let nsError = error as NSError? {
+                    os_log("❌ NSError Domain: %@", log: self.appLog, type: .debug, nsError.domain)
+                    os_log("❌ NSError Code: %d", log: self.appLog, type: .debug, nsError.code as CVarArg)
+                    os_log("❌ NSError UserInfo: %@", log: self.appLog, type: .debug, nsError.userInfo)
+                }
+                
+                if let urlError = error as? URLError {
+                    os_log("❌ URLError Code: %d", log: self.appLog, type: .debug, urlError.code.rawValue)
+                    os_log("❌ URLError LocalizedDescription: %@", log: self.appLog, type: .debug, urlError.localizedDescription)
+                    os_log("❌ URLError FailingURL: %@", log: self.appLog, type: .debug, urlError.failingURL?.absoluteString ?? "nil")
+                }
+                
+                os_log("❌ ====================================", log: self.appLog, type: .debug)
             }
-            
-            if let urlError = error as? URLError {
-                print("❌ URLError Code: \(urlError.code)")
-                print("❌ URLError LocalizedDescription: \(urlError.localizedDescription)")
-                print("❌ URLError FailingURL: \(urlError.failingURL?.absoluteString ?? "nil")")
-            }
-            print("❌ ====================================")
         }
 
         finishDownload(request: request)

--- a/torjolan/Services/StreamLoader.swift
+++ b/torjolan/Services/StreamLoader.swift
@@ -45,7 +45,7 @@ public final class StreamLoader: NSObject {
     }
 
     func appendData(_ data: Data) {
-        os_log("appendData", log: self.appLog, type: .debug)
+        // os_log("appendData", log: self.appLog, type: .debug)
         queue.async {
             self.dataQueue.append(data)
 
@@ -71,7 +71,7 @@ extension StreamLoader: AVAssetResourceLoaderDelegate {
         _ resourceLoader: AVAssetResourceLoader,
         shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest
     ) -> Bool {
-        os_log("resourceLoader: URL=%@\nHeaders=%@", log: self.appLog, type: .info,
+        os_log("resourceLoader: URL=%@\nHeaders=%@", log: self.appLog, type: .debug,
                loadingRequest.request.url?.absoluteString ?? "nil",
                loadingRequest.request.allHTTPHeaderFields ?? [:]
         )
@@ -188,7 +188,7 @@ extension StreamLoader: AVAssetResourceLoaderDelegate {
                 let newCurrentOffset = Int(dataRequest.currentOffset)
                 let totalSent = newCurrentOffset
                 if totalSent >= requested {
-                    os_log("pendingRequest(%d): %@: is complete!", log: self.appLog, type: .info, index, request)
+                    os_log("pendingRequest(%d): %@: is complete!", log: self.appLog, type: .debug, index, request.request.url?.absoluteString ?? "")
 
                     // Let the request know it is all done
                     request.finishLoading()
@@ -208,13 +208,13 @@ extension StreamLoader: AVAssetResourceLoaderDelegate {
         _ resourceLoader: AVAssetResourceLoader,
         didCancel loadingRequest: AVAssetResourceLoadingRequest
     ) {
-        os_log("resourceLoader didCancel: %@, url=%@", log: self.appLog, type: .info,
-               loadingRequest, loadingRequest.request.url?.absoluteString ?? "nil")
+        os_log("resourceLoader didCancel: url=%@", log: self.appLog, type: .info,
+               loadingRequest.request.url?.absoluteString ?? "nil")
         
         // Remove from pending requests if it exists
         if let index = pendingRequests.firstIndex(where: { $0 === loadingRequest }) {
             let req = pendingRequests[index]
-            os_log("Removing cancelled request from queue: %@", log: self.appLog, type: .info, req)
+            os_log("Removing cancelled request from queue: %@", log: self.appLog, type: .info, req.request.url?.absoluteString ?? "")
 
             pendingRequests.remove(at: index)
 

--- a/torjolan/Services/StreamLoader.swift
+++ b/torjolan/Services/StreamLoader.swift
@@ -9,9 +9,12 @@ public final class StreamLoader: NSObject {
     private let contentType: String
     private let utiContentType: String
     private let contentSize: Int64
+    private var isComplete: Bool = false
+    private let songId: String
     private let appLog = OSLog(subsystem: "net.line72.torjolan", category: "StreamLoader")
 
-    init(contentType: String, contentSize: Int64) {
+    init(songId: String, contentType: String, contentSize: Int64) {
+        self.songId = songId
         self.contentType = contentType
         // Map MIME type to UTI identifier for AVFoundation
         if let ut = UTType(mimeType: contentType)?.identifier {
@@ -56,7 +59,8 @@ public final class StreamLoader: NSObject {
     }
 
     func signalEndOfStream() {
-        os_log("signalEndOfStream: %d|%d", log: self.appLog, type: .info, self.dataQueue.count, self.contentSize)
+        os_log("signalEndOfStream for %@: %d|%d", log: self.appLog, type: .info, self.songId, self.dataQueue.count, self.contentSize)
+        self.isComplete = true
         queue.async {
             self.processPendingRequests() // Drain final data
             // Do not forcibly finish pending requests here. Allow any late
@@ -71,31 +75,60 @@ extension StreamLoader: AVAssetResourceLoaderDelegate {
         _ resourceLoader: AVAssetResourceLoader,
         shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest
     ) -> Bool {
-        os_log("resourceLoader: URL=%@\nHeaders=%@", log: self.appLog, type: .debug,
+        os_log("resourceLoader for %@: URL=%@\nHeaders=%@", log: self.appLog, type: .debug,
+               self.songId,
                loadingRequest.request.url?.absoluteString ?? "nil",
                loadingRequest.request.allHTTPHeaderFields ?? [:]
         )
 
         // ✅ 1. Populate metadata if requested (do not finish yet if there is also a dataRequest)
         if let info = loadingRequest.contentInformationRequest {
-            os_log("Returning meta for a contentInformationRequest: contentType=%@, contentSize=%d",
+            os_log("Returning meta for a contentInformationRequest for %@: contentType=%@, contentSize=%d",
                    log: self.appLog, type: .debug,
+                   self.songId,
                    self.contentType, self.contentSize)
 
             // Set content information expected by AVFoundation (UTI, not MIME)
             info.contentType = self.utiContentType
-            info.contentLength = self.contentSize
-            info.isByteRangeAccessSupported = true
+            if (self.contentSize == 0) {
+                os_log("No contentSize for %@ - we must be transcoding", log: self.appLog, type: .debug,
+                       self.songId)
+                // if transcoding, we don't have a valid contentLenght
+                // and can't use byteRangeAccessSuport
+                //
+                // It appears, AVPlayer is fucking dumb when it comes
+                //  to streaming without a known content length. The
+                //  recommendation appears to be to use HLS instead,
+                //  but navidrome does not support this. So, instead,
+                //  we are going to tell it the content length is
+                //  something really big, so it'll keep making
+                //  requests until we tell it, it is the end of the
+                //  stream.
+                //
+                // !mwd - Note, this doesn't really work. AVPlayer
+                // shows a ridiculous duration (72+ minutes). AVPlayer
+                // keeps making requests to the delegate, even though
+                // we have called finishLoading. It does seem to
+                // eventually stop, but AVPlayer just hangs forever,
+                // and never goes to the next song.
+                
+                info.contentLength = 100 * 1024 * 1024 // 100MB
+                info.isByteRangeAccessSupported = false
+            } else {
+                info.contentLength = self.contentSize
+                info.isByteRangeAccessSupported = true
+            }
         }
 
         // ✅ 2. If there's a dataRequest, queue it and start fulfilling
         if loadingRequest.dataRequest != nil {
-            os_log("queuing new request: %@", log: self.appLog, type: .debug,
-                   loadingRequest)
+            os_log("queuing new request from %@: %@", log: self.appLog, type: .debug,
+                   self.songId, loadingRequest)
 
             self.pendingRequests.append(loadingRequest)
 
-            os_log("Number of pending requests=: %d", log: self.appLog, type: .debug, self.pendingRequests.count)
+            os_log("Number of pending requests from %@ =: %d", log: self.appLog, type: .debug,
+                   self.songId, self.pendingRequests.count)
             if self.dataQueue.count > 0 {
                 self.processPendingRequests()
             }
@@ -104,13 +137,14 @@ extension StreamLoader: AVAssetResourceLoaderDelegate {
 
         // ✅ 3. If metadata-only request, we can finish now
         if loadingRequest.contentInformationRequest != nil {
-            os_log("contentInformationRequest is complete", log: self.appLog, type: .debug)
+            os_log("contentInformationRequest is complete from %@", log: self.appLog, type: .debug, self.songId)
             
             loadingRequest.finishLoading()
             return true
         }
 
-        os_log("❌ Unhandled Request Type, no contentInformationRequest or dataRequest!", log: self.appLog, type: .error)
+        os_log("❌ Unhandled Request Type from %@, no contentInformationRequest or dataRequest!", log: self.appLog, type: .error,
+               self.songId)
         return false
     }
     
@@ -118,7 +152,8 @@ extension StreamLoader: AVAssetResourceLoaderDelegate {
         guard !pendingRequests.isEmpty else { return }
         guard dataQueue.count != 0 else { return }
 
-        os_log("processPendingRequests: count=%d", log: self.appLog, type: .debug, self.pendingRequests.count)
+        os_log("processPendingRequests from %@: count=%d", log: self.appLog, type: .debug,
+               self.songId, self.pendingRequests.count)
         
         var index = 0
         while (index < pendingRequests.count) {
@@ -128,14 +163,16 @@ extension StreamLoader: AVAssetResourceLoaderDelegate {
                 //  since we never should have added this to our pending request
                 //  if dataRequest was nil
                 // Just remove this from our list
-                os_log("❌ pendingRequest is missing a dataRequest!", log: self.appLog, type: .error)
+                os_log("❌ pendingRequest from %@ is missing a dataRequest!", log: self.appLog, type: .error,
+                       self.songId)
 
                 pendingRequests.remove(at: index)
                 
                 continue
             }
 
-            os_log("processing pendingRequest(%d): %@", log: self.appLog, type: .debug, index, request)
+            os_log("processing pendingRequest(%d) from %@: %@", log: self.appLog, type: .debug,
+                   index, self.songId, request)
 
             while true {
                 // Never exceed requestedLength
@@ -161,20 +198,33 @@ extension StreamLoader: AVAssetResourceLoaderDelegate {
                 let maxBoundary = min(dataQueue.count, requestedOffset + requested)
                 let available = maxBoundary - start
 
-                os_log("pendingRequest(%d): %@: requested=%d, requestedOffset=%d, currentOffset=%d, start=%d, maxBoundary=%d, available=%d",
+                os_log("pendingRequest(%d) from %@: %@: requested=%d, requestedOffset=%d, currentOffset=%d, start=%d, maxBoundary=%d, available=%d",
                        log: self.appLog, type: .debug,
-                       index, request,
+                       index, self.songId, request,
                        requested, requestedOffset, currentOffset,
                        start, maxBoundary, available)
 
-                if available <= 0 {
+                if available <= 0 && !self.isComplete {
                     // Not enough data yet
-                    os_log("pendingRequest(%d): %@: Not enough data for request", log: self.appLog, type: .debug,
-                           index, request)
+                    os_log("pendingRequest(%d) from %@: %@: Not enough data for request", log: self.appLog, type: .debug,
+                           index, self.songId, request)
 
                     // remove on to the next request as it might have
                     // a different range that we do have data for
                     index += 1
+                    break
+                } else if available <= 0 && self.isComplete {
+                    // we are done! We didn't have a valid contentLength
+                    // which is why we don't think we have any data left
+                    os_log("pendingRequest(%d) from %@: We have finished all the data", log: self.appLog, type: .debug,
+                           index, self.songId)
+
+                    // Let the request know it is all done
+                    request.finishLoading()
+
+                    // Remove this from anything we'll process
+                    pendingRequests.remove(at: index) // remove correct pending request
+                    
                     break
                 }
 
@@ -188,7 +238,30 @@ extension StreamLoader: AVAssetResourceLoaderDelegate {
                 let newCurrentOffset = Int(dataRequest.currentOffset)
                 let totalSent = newCurrentOffset
                 if totalSent >= requested {
-                    os_log("pendingRequest(%d): %@: is complete!", log: self.appLog, type: .debug, index, request.request.url?.absoluteString ?? "")
+                    os_log("pendingRequest(%d) from %@: %@: is complete!", log: self.appLog, type: .debug,
+                           index, self.songId, request.request.url?.absoluteString ?? "")
+
+                    // Let the request know it is all done
+                    request.finishLoading()
+
+                    // Remove this from anything we'll process
+                    pendingRequests.remove(at: index) // remove correct pending request
+                    
+                    break
+                }
+
+                // For streaming, we don't have a valid contentLength,
+                // so we need to wait until the data is complete, and
+                // use that as our final size
+                if (self.isComplete) {
+                    os_log("pendingRequest(%d) from %@: we are complete, but haven't sent all data: dataQueue=%d, totalSent=%d, pendingRequest=%@",
+                           log: self.appLog, type: .debug,
+                           index, self.songId, self.dataQueue.count, totalSent, request)
+                }
+                             
+                if self.isComplete && totalSent >= self.dataQueue.count {
+                    os_log("pendingRequest(%d) from %@ has hit the final length", log: self.appLog, type: .debug,
+                           index, self.songId)
 
                     // Let the request know it is all done
                     request.finishLoading()
@@ -201,24 +274,27 @@ extension StreamLoader: AVAssetResourceLoaderDelegate {
             }
         }
 
-        os_log("processPendingRequests complete. Number of pendingRequests=%d", log: self.appLog, type: .debug, self.pendingRequests.count)
+        os_log("processPendingRequests from %@ complete. Number of pendingRequests=%d", log: self.appLog, type: .debug,
+               self.songId, self.pendingRequests.count)
     }
     
     public func resourceLoader(
         _ resourceLoader: AVAssetResourceLoader,
         didCancel loadingRequest: AVAssetResourceLoadingRequest
     ) {
-        os_log("resourceLoader didCancel: url=%@", log: self.appLog, type: .info,
-               loadingRequest.request.url?.absoluteString ?? "nil")
+        os_log("resourceLoader didCancel for %@: url=%@", log: self.appLog, type: .info,
+               self.songId, loadingRequest.request.url?.absoluteString ?? "nil")
         
         // Remove from pending requests if it exists
         if let index = pendingRequests.firstIndex(where: { $0 === loadingRequest }) {
             let req = pendingRequests[index]
-            os_log("Removing cancelled request from queue: %@", log: self.appLog, type: .info, req.request.url?.absoluteString ?? "")
+            os_log("Removing cancelled request from queue for %@: %@", log: self.appLog, type: .info,
+                   self.songId, req.request.url?.absoluteString ?? "")
 
             pendingRequests.remove(at: index)
 
-            os_log("Number of pending requests after cancel=%d", log: self.appLog, type: .debug, self.pendingRequests.count)
+            os_log("Number of pending requests after cancel from %@=%d", log: self.appLog, type: .debug,
+                   self.songId, self.pendingRequests.count)
         }
     }
 }

--- a/torjolan/Views/PlayerView.swift
+++ b/torjolan/Views/PlayerView.swift
@@ -670,6 +670,10 @@ struct PlayerView: View {
             audioPlayer.stop()
             // Start playing next song
             audioPlayer.startPlayingStation(station)
+
+            // cancel the download of the existing (if still working)
+            //  to make sure the next in line starts
+            DownloadCacheManager.shared.cancel(songId: song.id)
         }
     }
 

--- a/torjolan/Views/PlayerView.swift
+++ b/torjolan/Views/PlayerView.swift
@@ -673,7 +673,7 @@ struct PlayerView: View {
 
             // cancel the download of the existing (if still working)
             //  to make sure the next in line starts
-            DownloadCacheManager.shared.cancel(songId: song.id)
+            await DownloadCacheManager.shared.cancel(songId: song.id)
         }
     }
 

--- a/torjolan/Views/PlayerView.swift
+++ b/torjolan/Views/PlayerView.swift
@@ -162,7 +162,7 @@ class AudioPlayer: NSObject, ObservableObject {
 
         do {
             let streamLoader = await DownloadCacheManager.shared.queueFirst(
-              songId: song.id,
+              song: song,
               url: URL(string: stationResponse.track.url)!
             )
             
@@ -202,7 +202,7 @@ class AudioPlayer: NSObject, ObservableObject {
                 let firstStream = streamResponseList.tracks[0]
                 let song = Song(from: firstStream)
                 let streamLoader = await DownloadCacheManager.shared.queueFirst(
-                    songId: song.id,
+                    song: song,
                     url: URL(string: firstStream.url)!
                 )
 
@@ -218,7 +218,7 @@ class AudioPlayer: NSObject, ObservableObject {
                 for stream in streamResponseList.tracks.dropFirst() {
                     let song2 = Song(from: stream)
                     let _ = await DownloadCacheManager.shared.queue(
-                      songId: song2.id,
+                      song: song2,
                       url: URL(string: stream.url)!
                     )
                 }
@@ -257,7 +257,7 @@ class AudioPlayer: NSObject, ObservableObject {
                 let firstStream = streamResponseList.tracks[0]
                 let song = Song(from: firstStream)
                 let streamLoader = await DownloadCacheManager.shared.queueFirst(
-                    songId: song.id,
+                    song: song,
                     url: URL(string: firstStream.url)!
                 )
 
@@ -274,7 +274,7 @@ class AudioPlayer: NSObject, ObservableObject {
                 for stream in streamResponseList.tracks.dropFirst() {
                     let song2 = Song(from: stream)
                     let _ = await DownloadCacheManager.shared.queue(
-                      songId: song2.id,
+                      song: song2,
                       url: URL(string: stream.url)!
                     )
                 }
@@ -380,58 +380,59 @@ class AudioPlayer: NSObject, ObservableObject {
     }
 
     private func logDetailedPlayerError(playerItem: AVPlayerItem?, song: Song) {
-        print("❌ ========== PLAYER ITEM FAILED ==========")
-        print("❌ Song ID: \(song.id)")
-        print("❌ Song Title: \(song.title)")
-        print("❌ Song Artist: \(song.artist)")
+        os_log("❌ ========== PLAYER ITEM FAILED ==========", log: self.appLog, type: .error)
+        os_log("❌ Song ID: %@", log: self.appLog, type: .error, song.id)
+        os_log("❌ Song Title: %@", log: self.appLog, type: .error, song.title)
+        os_log("❌ Song Artist: %@", log: self.appLog, type: .error, song.artist)
         
         if let error = playerItem?.error {
-            print("❌ Primary Error: \(error.localizedDescription)")
+            os_log("❌ Primary Error: %@", log: self.appLog, type: .error, error.localizedDescription)
             
             if let nsError = error as NSError? {
-                print("❌ Error Code: \(nsError.code)")
-                print("❌ Error Domain: \(nsError.domain)")
+                os_log("❌ Error Code: %d", log: self.appLog, type: .error, nsError.code as CVarArg)
+                os_log("❌ Error Domain: %@", log: self.appLog, type: .error, nsError.domain)
             }
             
             // Check for underlying errors
             if let nsError = error as NSError? {
-                print("❌ NSError Code: \(nsError.code)")
-                print("❌ NSError Domain: \(nsError.domain)")
-                print("❌ NSError UserInfo: \(nsError.userInfo)")
+                os_log("❌ NSError Code: %d", log: self.appLog, type: .error, nsError.code as CVarArg)
+                os_log("❌ NSError Domain: %@", log: self.appLog, type: .error, nsError.domain)
+                os_log("❌ NSError UserInfo: %@", log: self.appLog, type: .error, nsError.userInfo)
                 
                 // Check for underlying error in userInfo
                 if let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
-                    print("❌ Underlying Error: \(underlyingError.localizedDescription)")
-                    print("❌ Underlying Error Code: \(underlyingError.code)")
-                    print("❌ Underlying Error Domain: \(underlyingError.domain)")
-                    print("❌ Underlying Error UserInfo: \(underlyingError.userInfo)")
+                    os_log("❌ Underlying Error: %@", log: self.appLog, type: .error, underlyingError.localizedDescription)
+                    os_log("❌ Underlying Error Code: %d", log: self.appLog, type: .error, underlyingError.code as CVarArg)
+                    os_log("❌ Underlying Error Domain: %@", log: self.appLog, type: .error, underlyingError.domain)
+                    os_log("❌ Underlying Error UserInfo: %@", log: self.appLog, type: .error, underlyingError.userInfo)
                 }
                 
                 // Check for OSStatus errors (common in AVFoundation)
                 if nsError.domain == NSOSStatusErrorDomain {
                     let osStatus = OSStatus(nsError.code)
-                    print("❌ OSStatus: \(osStatus) (\(fourCharCodeFromOSStatus(osStatus)))")
+                    os_log("❌ OSStatus: %d %@", log: self.appLog, type: .error,
+                           nsError.code as CVarArg, fourCharCodeFromOSStatus(osStatus))
                 }
             }
         } else {
-            print("❌ No error object available")
+            os_log("❌ No error object available", log: self.appLog, type: .error)
         }
         
         // Check asset information
         if let asset = playerItem?.asset {
             // Check if it's an AVURLAsset first to get URL
             if let urlAsset = asset as? AVURLAsset {
-                print("❌ AVURLAsset URL: \(urlAsset.url)")
-                print("❌ AVURLAsset ResourceLoader: \(urlAsset.resourceLoader)")
+                os_log("❌ AVURLAsset URL: %@", log: self.appLog, type: .error, urlAsset.url.absoluteString)
+                os_log("❌ AVURLAsset ResourceLoader: %@", log: self.appLog, type: .error, urlAsset.resourceLoader)
                 
                 // Check if resource loader has a delegate
                 if urlAsset.resourceLoader.delegate != nil {
-                    print("❌ ResourceLoader has delegate: YES")
+                    os_log("❌ ResourceLoader has delegate: YES", log: self.appLog, type: .error)
                 } else {
-                    print("❌ ResourceLoader has delegate: NO")
+                    os_log("❌ ResourceLoader has delegate: NO", log: self.appLog, type: .error)
                 }
             } else {
-                print("❌ Asset is not AVURLAsset: \(type(of: asset))")
+                os_log("❌ Asset is not AVURLAsset: %@", log: self.appLog, type: .error, String(reflecting: type(of: asset)))
             }
             
             // Use async loading for modern iOS versions to avoid deprecation warnings
@@ -443,32 +444,35 @@ class AudioPlayer: NSObject, ObservableObject {
                     let isExportable = try await asset.load(.isExportable)
                     let isComposable = try await asset.load(.isComposable)
                     
-                    print("❌ Asset Duration: \(duration)")
-                    print("❌ Asset Playable: \(isPlayable)")
-                    print("❌ Asset Readable: \(isReadable)")
-                    print("❌ Asset Exportable: \(isExportable)")
-                    print("❌ Asset Composable: \(isComposable)")
+                    os_log("❌ Asset Duration: %d", log: self.appLog, type: .error, CMTimeGetSeconds(duration))
+                    os_log("❌ Asset Playable: %d", log: self.appLog, type: .error, isPlayable)
+                    os_log("❌ Asset Readable: %d", log: self.appLog, type: .error, isReadable)
+                    os_log("❌ Asset Exportable: %d", log: self.appLog, type: .error, isExportable)
+                    os_log("❌ Asset Composable: %d", log: self.appLog, type: .error, isComposable)
                 } catch {
-                    print("❌ Failed to load asset properties: \(error)")
+                    os_log("❌ Failed to load asset properties: %@", log: self.appLog, type: .error, String(describing: error))
                 }
             }
         }
         
         // Check player item tracks
         if let tracks = playerItem?.tracks {
-            print("❌ Player Item Tracks Count: \(tracks.count)")
+            os_log("❌ Player Item Tracks Count: %d", log: self.appLog, type: .error, tracks.count)
             for (index, track) in tracks.enumerated() {
-                print("❌ Track \(index): enabled=\(track.isEnabled), asset track=\(track.assetTrack?.mediaType.rawValue ?? "nil")")
+                os_log("❌ Track %d: enabled=%d, asset track=%@",
+                       log: self.appLog, type: .error,
+                       index, track.isEnabled, track.assetTrack?.mediaType.rawValue ?? "nil"
+                )
             }
         }
         
         // Check audio session
         let audioSession = AVAudioSession.sharedInstance()
-        print("❌ Audio Session Category: \(audioSession.category.rawValue)")
-        print("❌ Audio Session Active: \(audioSession.isOtherAudioPlaying)")
-        print("❌ Audio Session Route: \(audioSession.currentRoute)")
+        os_log("❌ Audio Session Category: %@", log: self.appLog, type: .error, audioSession.category.rawValue)
+        os_log("❌ Audio Session Active: %d", log: self.appLog, type: .error, audioSession.isOtherAudioPlaying)
+        os_log("❌ Audio Session Route: %@", log: self.appLog, type: .error, audioSession.currentRoute)
         
-        print("❌ ========================================")
+        os_log("❌ ========================================", log: self.appLog, type: .error)
     }
     
     private func fourCharCodeFromOSStatus(_ status: OSStatus) -> String {

--- a/torjolan/Views/PlayerView.swift
+++ b/torjolan/Views/PlayerView.swift
@@ -161,7 +161,7 @@ class AudioPlayer: NSObject, ObservableObject {
         let song = Song(from: stationResponse.track)
 
         do {
-            let streamLoader = await DownloadCacheManager.shared.queue(
+            let streamLoader = await DownloadCacheManager.shared.queueFirst(
               songId: song.id,
               url: URL(string: stationResponse.track.url)!
             )
@@ -201,7 +201,7 @@ class AudioPlayer: NSObject, ObservableObject {
                 // Queue up and start playing the first song in the response
                 let firstStream = streamResponseList.tracks[0]
                 let song = Song(from: firstStream)
-                let streamLoader = await DownloadCacheManager.shared.queue(
+                let streamLoader = await DownloadCacheManager.shared.queueFirst(
                     songId: song.id,
                     url: URL(string: firstStream.url)!
                 )
@@ -256,7 +256,7 @@ class AudioPlayer: NSObject, ObservableObject {
                 // Queue up and start playing the first song in the response
                 let firstStream = streamResponseList.tracks[0]
                 let song = Song(from: firstStream)
-                let streamLoader = await DownloadCacheManager.shared.queue(
+                let streamLoader = await DownloadCacheManager.shared.queueFirst(
                     songId: song.id,
                     url: URL(string: firstStream.url)!
                 )


### PR DESCRIPTION
Resolves #18

- **Allow inserting new songs we want to play at the front of the queue**
- **Keep track of our download tasks, so we can cancel them. Force the next song to start downloading, even if we are over our max current limit. This make sure the song about to play starts downloading immediately.**
- **Clean up some output due to a cancel**
